### PR TITLE
Speedup of the profile identifying process.

### DIFF
--- a/sumup.py
+++ b/sumup.py
@@ -81,15 +81,16 @@ def sumup(writer):
     lon[mk] = -60.0
     ##############
 
-    ### Find all of the unique cores (slow)
-    llpair=np.array((lat,lon)).T
-    xx=np.c_[lat,lon,cite,date]
-    core_unique = np.unique(xx,axis=0)
-    coreid = np.zeros(len(xx))
-
-    for ii,features in enumerate(core_unique):
-        inds = np.where((xx==features).all(axis=1))[0]
-        coreid[inds]=ii+1
+    ### Find all of the unique cores (not as slow as before)
+    phash = np.array([lat, lon, cite, date]).transpose().astype(str)
+    phash = np.array([hash(''.join(phash[n,:])) for n in range(len(phash))])
+    coreid = np.zeros_like(lat)
+    id_no = 1
+    
+    for h in set(phash):
+        inds = np.where(phash == h)
+        coreid[inds] = id_no
+        id_no += 1
     coreid = coreid.astype(int)
     ##############
 


### PR DESCRIPTION
Lately I made my own approach to digging into the SUMup data set and stumbled over the fact that it lacks an identifier for individual firn profiles. The solution I came up with is to write all the metadata of a data point (date, location, citation, SDOS-flag, method) into one string. This string is already an identifier. For better handling, less memory overhead and speed considerations, I hashed these strings using the build in ```hash()``` function of python3.

To compare my results I checked out the SumUpTools. As I got stomachache from too much coffee I decided implement my method of finding firn profiles within the data set and to write a pull request. Feel free to apply my changes or not.

Timm